### PR TITLE
Add island inspiration ratio feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ llm:
 database:
   population_size: 500
   num_islands: 5
+  island_inspiration_ratio: 0.0
 ```
 
 Sample configuration files are available in the `configs/` directory:

--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -82,6 +82,7 @@ database:
   # Migration periodically shares the best solutions between adjacent islands.
   migration_interval: 50              # Migrate between islands every N generations
   migration_rate: 0.1                 # Fraction of top programs to migrate (0.1 = 10%)
+  island_inspiration_ratio: 0.0       # Portion of inspirations drawn from the current island
 
   # Selection parameters
   elite_selection_ratio: 0.1          # Ratio of elite programs to select

--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -161,6 +161,9 @@ class DatabaseConfig:
     migration_interval: int = 50  # Migrate every N generations
     migration_rate: float = 0.1  # Fraction of population to migrate
 
+    # Inspiration sampling
+    island_inspiration_ratio: float = 0.0  # Fraction of inspirations from the current island
+
     # Random seed for reproducible sampling
     random_seed: Optional[int] = None
 
@@ -307,6 +310,7 @@ class Config:
                 "feature_bins": self.database.feature_bins,
                 "migration_interval": self.database.migration_interval,
                 "migration_rate": self.database.migration_rate,
+                "island_inspiration_ratio": self.database.island_inspiration_ratio,
                 "random_seed": self.database.random_seed,
             },
             "evaluator": {

--- a/openevolve/database.py
+++ b/openevolve/database.py
@@ -643,23 +643,47 @@ class ProgramDatabase:
         """
         inspirations = []
 
+        # Optionally sample a portion of inspirations from the parent's island
+        island_ratio = getattr(self.config, "island_inspiration_ratio", 0.0)
+        island_samples = int(n * island_ratio)
+        if island_samples > 0:
+            parent_island = parent.metadata.get("island", self.current_island)
+            island_pool = [
+                pid
+                for pid in self.islands[parent_island]
+                if pid in self.programs and pid != parent.id
+            ]
+            if island_pool:
+                sample_ids = random.sample(island_pool, min(island_samples, len(island_pool)))
+                inspirations.extend(self.programs[pid] for pid in sample_ids)
+
+        remaining_slots = n - len(inspirations)
+
         # Always include the absolute best program if available and different from parent
-        if self.best_program_id is not None and self.best_program_id != parent.id:
+        if (
+            remaining_slots > 0
+            and self.best_program_id is not None
+            and self.best_program_id != parent.id
+            and self.best_program_id not in [p.id for p in inspirations]
+        ):
             best_program = self.programs[self.best_program_id]
             inspirations.append(best_program)
+            remaining_slots -= 1
             logger.debug(f"Including best program {self.best_program_id} in inspirations")
 
         # Add top programs as inspirations
-        top_n = max(1, int(n * self.config.elite_selection_ratio))
-        top_programs = self.get_top_programs(n=top_n)
-        for program in top_programs:
-            if program.id not in [p.id for p in inspirations] and program.id != parent.id:
-                inspirations.append(program)
+        if remaining_slots > 0:
+            top_n = max(1, int(n * self.config.elite_selection_ratio))
+            top_programs = self.get_top_programs(n=top_n)
+            for program in top_programs:
+                if remaining_slots <= 0:
+                    break
+                if program.id not in [p.id for p in inspirations] and program.id != parent.id:
+                    inspirations.append(program)
+                    remaining_slots -= 1
 
         # Add diverse programs using config.num_diverse_programs
-        if len(self.programs) > n and len(inspirations) < n:
-            # Calculate how many diverse programs to add (up to remaining slots)
-            remaining_slots = n - len(inspirations)
+        if len(self.programs) > n and remaining_slots > 0:
 
             # Sample from different feature cells for diversity
             feature_coords = self._calculate_feature_coords(parent)
@@ -697,6 +721,7 @@ class ProgramDatabase:
                     nearby_programs.extend(random_programs)
 
             inspirations.extend(nearby_programs)
+            remaining_slots = n - len(inspirations)
 
         return inspirations[:n]
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -80,6 +80,28 @@ class TestProgramDatabase(unittest.TestCase):
         self.assertIsNotNone(parent)
         self.assertIn(parent.id, ["test1", "test2"])
 
+    def test_island_inspiration_ratio(self):
+        """Inspirations can be forced to come from the current island"""
+        config = Config()
+        config.database.in_memory = True
+        config.database.num_islands = 2
+        config.database.exploration_ratio = 1.0
+        config.database.island_inspiration_ratio = 1.0
+        db = ProgramDatabase(config.database)
+
+        p1 = Program(id="p1", code="a", metrics={"score": 0.1})
+        p2 = Program(id="p2", code="b", metrics={"score": 0.2})
+        db.add(p1, target_island=0)
+        db.add(p2, target_island=0)
+
+        p3 = Program(id="p3", code="c", metrics={"score": 0.3})
+        db.add(p3, target_island=1)
+
+        db.set_current_island(0)
+        parent, inspirations = db.sample()
+
+        self.assertTrue(all(prog.metadata.get("island") == 0 for prog in inspirations))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- let database config pick `island_inspiration_ratio`
- sample inspirations from parent's island using the ratio
- document the option in README and default config
- test coverage for new feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6847672542e4832bad16cb277fb4b6ae