### PR TITLE
Improve program details in visualizer

### DIFF
--- a/scripts/static/js/sidebar.js
+++ b/scripts/static/js/sidebar.js
@@ -33,6 +33,7 @@ export function showSidebarContent(d, fromHover = false) {
     let tabNames = [];
     if (d.code && typeof d.code === 'string' && d.code.trim() !== '') tabNames.push('Code');
     if (d.prompts && typeof d.prompts === 'object' && Object.keys(d.prompts).length > 0) tabNames.push('Prompts');
+    if (d.llm_output && typeof d.llm_output === 'string' && d.llm_output.trim() !== '') tabNames.push('Output');
     const children = allNodeData.filter(n => n.parent_id === d.id);
     if (children.length > 0) tabNames.push('Children');
     let activeTab = lastSidebarTab && tabNames.includes(lastSidebarTab) ? lastSidebarTab : tabNames[0];
@@ -48,6 +49,9 @@ export function showSidebarContent(d, fromHover = false) {
                 html += `<div style="margin-bottom:0.7em;"><b>${k}:</b><pre class="sidebar-pre">${v}</pre></div>`;
             }
             return html;
+        }
+        if (tabName === 'Output') {
+            return `<pre class="sidebar-pre">${d.llm_output}</pre>`;
         }
         if (tabName === 'Children') {
             const metric = (document.getElementById('metric-select') && document.getElementById('metric-select').value) || 'combined_score';
@@ -89,6 +93,7 @@ export function showSidebarContent(d, fromHover = false) {
             <b>Program ID:</b> ${d.id}<br>
             <b>Island:</b> ${d.island}<br>
             <b>Generation:</b> ${d.generation}<br>
+            <b>Model:</b> ${d.model || 'unknown'}<br>
             <b>Parent ID:</b> <a href="#" class="parent-link" data-parent="${d.parent_id || ''}">${d.parent_id || 'None'}</a>${parentIslandHtml}<br><br>
             <b>Metrics:</b><br>${formatMetrics(d.metrics)}<br><br>
             ${tabHtml}${tabContentHtml}

--- a/scripts/templates/program_page.html
+++ b/scripts/templates/program_page.html
@@ -15,6 +15,7 @@
         <li><strong>Island:</strong> {{ program_data.island }}</li>
         <li><strong>Generation:</strong> {{ program_data.generation }}</li>
         <li><strong>Parent ID:</strong> {{ program_data.parent_id or 'None' }}</li>
+        <li><strong>Model:</strong> {{ program_data.model or 'Unknown' }}</li>
         <li><strong>Metrics:</strong>
             <ul>
                 {% for key, value in program_data.metrics.items() %}
@@ -31,5 +32,9 @@
             <li><strong>{{ key }}:</strong> <pre style="white-space: pre-wrap; word-break: break-word;">{{ value }}</pre></li>
         {% endfor %}
     </ul>
+    {% if program_data.llm_output %}
+    <h2>LLM Output:</h2>
+    <pre style="white-space: pre-wrap; word-break: break-word;">{{ program_data.llm_output }}</pre>
+    {% endif %}
 </body>
 </html>

--- a/scripts/visualizer.py
+++ b/scripts/visualizer.py
@@ -43,7 +43,18 @@ def load_evolution_data(checkpoint_folder):
             if os.path.exists(prog_path):
                 with open(prog_path) as pf:
                     prog = json.load(pf)
+
                 prog["island"] = island_idx
+
+                # Extract metadata fields that are useful for the UI
+                meta_fields = prog.get("metadata", {}) if isinstance(prog.get("metadata"), dict) else {}
+                if "prompts" in meta_fields and isinstance(meta_fields["prompts"], dict):
+                    prog["prompts"] = meta_fields["prompts"]
+                if "llm_output" in meta_fields:
+                    prog["llm_output"] = meta_fields["llm_output"]
+                if "model" in meta_fields:
+                    prog["model"] = meta_fields["model"]
+
                 nodes.append(prog)
                 id_to_program[pid] = prog
             else:
@@ -95,7 +106,13 @@ def program_page(program_id):
 
     data = load_evolution_data(checkpoint_dir)
     program_data = next((p for p in data["nodes"] if p["id"] == program_id), None)
-    program_data = {"code": "", "prompts": {}, **program_data}
+    program_data = {
+        "code": "",
+        "prompts": {},
+        "llm_output": "",
+        "model": "",
+        **program_data,
+    }
 
     return render_template(
         "program_page.html", program_data=program_data, checkpoint_dir=checkpoint_dir


### PR DESCRIPTION
## Summary
- surface prompts, LLM output and model info from metadata
- show model and full LLM output in the program page
- add new "Output" sidebar tab to view the non‑code text

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6851cb8468a0832bb7f93746ee2be6c3